### PR TITLE
Mobile first

### DIFF
--- a/content/presentation/src/main/java/com/example/content/presentation/home/HomeScreen.kt
+++ b/content/presentation/src/main/java/com/example/content/presentation/home/HomeScreen.kt
@@ -16,20 +16,21 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.content.presentation.home.component.PokemonCard
 import com.example.content.presentation.home.component.paletteBackgroundColor
-import com.example.content.presentation.home.model.PokemonUi
+import com.example.content.presentation.home.mapper.toPokemonUi
+import com.example.core.domain.content.Pokemon
 import com.example.core.presentation.designsystem.JetpackApplicationTheme
 import com.kmpalette.palette.graphics.Palette
 import org.koin.androidx.compose.koinViewModel
-import timber.log.Timber
 
 @Composable
 fun HomeScreenRoot(
   viewModel: HomeViewModel = koinViewModel()
 ) {
   val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+  val pokemonList by viewModel.pokemonList.collectAsStateWithLifecycle()
 
   HomeScreen(
-    state = viewModel.state,
+    pokemonList = pokemonList,
     uiState = uiState,
     onAction = viewModel::onAction
   )
@@ -37,7 +38,7 @@ fun HomeScreenRoot(
 
 @Composable
 private fun HomeScreen(
-  state: HomeState,
+  pokemonList: List<Pokemon>,
   uiState: HomeUiState,
   onAction: (HomeAction) -> Unit,
 ) {
@@ -51,11 +52,10 @@ private fun HomeScreen(
       contentPadding = PaddingValues(6.dp),
     ) {
       itemsIndexed(
-        items = state.pokemonList,
+        items = pokemonList,
         key = { _, pokemon -> pokemon.name }
       ) { index, pokemon ->
-        if ((index + threadHold) >= state.pokemonList.size && uiState != HomeUiState.Loading) {
-          Timber.d("pokemonList.size: ${state.pokemonList.size}")
+        if ((index + threadHold) >= pokemonList.size && uiState != HomeUiState.Loading) {
           onAction(HomeAction.FetchPokemons)
         }
 
@@ -64,7 +64,7 @@ private fun HomeScreen(
 
         PokemonCard(
           backgroundColor = backgroundColor,
-          pokemonUi = pokemon,
+          pokemonUi = pokemon.toPokemonUi(),
           modifier = Modifier,
           onPaletteLoaded = { newPalette ->
             paletteMap[pokemon.imageUrl] = newPalette
@@ -77,32 +77,30 @@ private fun HomeScreen(
 
 @Preview
 @Composable
-private fun HomeScreenPreview() {
+fun HomeScreenPreview() {
   JetpackApplicationTheme {
     HomeScreen(
-      state = HomeState(
-        pokemonList = listOf(
-          PokemonUi(
-            page = 0,
-            nameField = "Pikachu",
-            url = "https://pokeapi.co/api/v2/pokemon/1/",
-          ),
-          PokemonUi(
-            page = 1,
-            nameField = "Bulbasaur",
-            url = "https://pokeapi.co/api/v2/pokemon/2/",
-          ),
-          PokemonUi(
-            page = 2,
-            nameField = "Charmander",
-            url = "https://pokeapi.co/api/v2/pokemon/3/",
-          ),
-          PokemonUi(
-            page = 3,
-            nameField = "Squirtle",
-            url = "https://pokeapi.co/api/v2/pokemon/4/",
-          ),
-        )
+      pokemonList = listOf(
+        Pokemon(
+          page = 0,
+          nameField = "Pikachu",
+          url = "https://pokeapi.co/api/v2/pokemon/1/",
+        ),
+        Pokemon(
+          page = 1,
+          nameField = "Bulbasaur",
+          url = "https://pokeapi.co/api/v2/pokemon/2/",
+        ),
+        Pokemon(
+          page = 2,
+          nameField = "Charmander",
+          url = "https://pokeapi.co/api/v2/pokemon/3/",
+        ),
+        Pokemon(
+          page = 3,
+          nameField = "Squirtle",
+          url = "https://pokeapi.co/api/v2/pokemon/4/",
+        ),
       ),
       uiState = HomeUiState.Idle,
       onAction = {}

--- a/content/presentation/src/main/java/com/example/content/presentation/home/HomeScreen.kt
+++ b/content/presentation/src/main/java/com/example/content/presentation/home/HomeScreen.kt
@@ -46,7 +46,7 @@ private fun HomeScreen(
   val paletteMap = remember { mutableStateMapOf<String, Palette>() }
 
   Box(modifier = Modifier.fillMaxSize()) {
-    val threadHold = 8
+    val threshold = 8
     LazyVerticalGrid(
       columns = GridCells.Fixed(2),
       contentPadding = PaddingValues(6.dp),
@@ -55,7 +55,7 @@ private fun HomeScreen(
         items = pokemonList,
         key = { _, pokemon -> pokemon.name }
       ) { index, pokemon ->
-        if ((index + threadHold) >= pokemonList.size && uiState != HomeUiState.Loading) {
+        if ((index + threshold) >= pokemonList.size && uiState != HomeUiState.Loading) {
           onAction(HomeAction.FetchPokemons)
         }
 

--- a/content/presentation/src/main/java/com/example/content/presentation/home/HomeState.kt
+++ b/content/presentation/src/main/java/com/example/content/presentation/home/HomeState.kt
@@ -1,7 +1,0 @@
-package com.example.content.presentation.home
-
-import com.example.content.presentation.home.model.PokemonUi
-
-data class HomeState(
-    val pokemonList: List<PokemonUi> = emptyList(),
-)

--- a/content/presentation/src/main/java/com/example/content/presentation/home/HomeViewModel.kt
+++ b/content/presentation/src/main/java/com/example/content/presentation/home/HomeViewModel.kt
@@ -35,7 +35,7 @@ class HomeViewModel(
     viewModelScope.launch {
       val result = repository.fetchPokemons(page = pokemonFetchingIndex.value)
       state = state.copy(
-        pokemonList = state.pokemonList + result.map { pokemon ->
+        pokemonList = result.map { pokemon ->
           PokemonUi(
             page = pokemon.page,
             nameField = pokemon.nameField,

--- a/content/presentation/src/main/java/com/example/content/presentation/home/HomeViewModel.kt
+++ b/content/presentation/src/main/java/com/example/content/presentation/home/HomeViewModel.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
 package com.example.content.presentation.home
 
 import androidx.compose.runtime.getValue
@@ -5,24 +7,36 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.content.presentation.home.model.PokemonUi
 import com.example.core.domain.content.PokeRepository
+import com.example.core.domain.content.Pokemon
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.stateIn
 
 class HomeViewModel(
   private val repository: PokeRepository,
 ) : ViewModel() {
-
-  var state by mutableStateOf(HomeState())
-    private set
+  
   val uiState: MutableStateFlow<HomeUiState> = MutableStateFlow(HomeUiState.Loading)
 
   private val pokemonFetchingIndex: MutableStateFlow<Int> = MutableStateFlow(0)
 
-  init {
-    fetchPokemon()
-  }
+  val pokemonList: StateFlow<List<Pokemon>> = pokemonFetchingIndex.flatMapLatest { page ->
+    repository.fetchPokemons(page)
+      .onStart { uiState.value = HomeUiState.Loading }
+      .onCompletion { uiState.value = HomeUiState.Idle }
+      .catch { exception -> uiState.value = HomeUiState.Error(exception.message) }
+  }.stateIn(
+    scope = viewModelScope,
+    started = SharingStarted.WhileSubscribed(5_000),
+    initialValue = emptyList(),
+  )
 
   fun onAction(action: HomeAction) {
     when (action) {
@@ -31,20 +45,6 @@ class HomeViewModel(
   }
 
   private fun fetchPokemon() {
-    uiState.value = HomeUiState.Loading
-    viewModelScope.launch {
-      val result = repository.fetchPokemons(page = pokemonFetchingIndex.value)
-      state = state.copy(
-        pokemonList = result.map { pokemon ->
-          PokemonUi(
-            page = pokemon.page,
-            nameField = pokemon.nameField,
-            url = pokemon.url,
-          )
-        },
-      )
-    }
-    uiState.value = HomeUiState.Idle
     if (uiState.value != HomeUiState.Loading) {
       pokemonFetchingIndex.value++
     }

--- a/content/presentation/src/main/java/com/example/content/presentation/home/mapper/pokemonUiMapper.kt
+++ b/content/presentation/src/main/java/com/example/content/presentation/home/mapper/pokemonUiMapper.kt
@@ -1,0 +1,12 @@
+package com.example.content.presentation.home.mapper
+
+import com.example.content.presentation.home.model.PokemonUi
+import com.example.core.domain.content.Pokemon
+
+fun Pokemon.toPokemonUi(): PokemonUi {
+  return PokemonUi(
+    page = page,
+    nameField = nameField,
+    url = url,
+  )
+}

--- a/core/data/src/main/java/com/example/core/data/content/OfflineFirstPokeRepository.kt
+++ b/core/data/src/main/java/com/example/core/data/content/OfflineFirstPokeRepository.kt
@@ -1,19 +1,46 @@
 package com.example.core.data.content
 
+import com.example.core.database.RoomLocalPokemonDataSource
 import com.example.core.domain.content.PokeRepository
 import com.example.core.domain.content.Pokemon
 import com.example.core.domain.content.RemotePokemonDataSource
+import com.example.core.domain.util.DataError
 import com.example.core.domain.util.Result
 
 class OfflineFirstPokeRepository(
   private val remotePokeDataSource: RemotePokemonDataSource,
-): PokeRepository {
+  private val localPokemonDataSource: RoomLocalPokemonDataSource
+) : PokeRepository {
 
   override suspend fun fetchPokemons(page: Int): List<Pokemon> {
-    remotePokeDataSource.getPokemonList(page).let { result ->
-      return when (result) {
-        is Result.Error -> emptyList()
-        is Result.Success -> result.data
+    return when (val pokemonList = localPokemonDataSource.fetchPokemonList(page)) {
+      is Result.Error -> {
+        return when (pokemonList.error) {
+          DataError.Local.DISK_FULL -> emptyList()
+          DataError.Local.UNKNOWN -> emptyList()
+          else -> emptyList()
+        }
+      }
+
+      is Result.Success -> {
+        if (pokemonList.data.isEmpty()) {
+          val results = remotePokeDataSource.getPokemonList(page).let { result ->
+            return@let when (result) {
+              is Result.Error -> emptyList()
+              is Result.Success -> result.data
+            }
+          }
+          results.forEach { result ->
+            result.page = page
+          }
+          localPokemonDataSource.insertPokemon(results)
+          return when (val pokemons = localPokemonDataSource.getAllPokemonList(page)) {
+            is Result.Error -> emptyList()
+            is Result.Success -> pokemons.data
+          }
+        } else {
+          return pokemonList.data
+        }
       }
     }
   }

--- a/core/database/src/main/java/com/example/core/database/RoomLocalPokemonDataSource.kt
+++ b/core/database/src/main/java/com/example/core/database/RoomLocalPokemonDataSource.kt
@@ -1,14 +1,36 @@
 package com.example.core.database
 
 import com.example.core.database.dao.PokemonDao
+import com.example.core.database.entity.mapper.asDomain
+import com.example.core.database.entity.mapper.asEntity
 import com.example.core.domain.content.LocalPokemonDataSource
 import com.example.core.domain.content.Pokemon
+import com.example.core.domain.util.DataError
+import com.example.core.domain.util.Result
 
 class RoomLocalPokemonDataSource(
   private val pokemonDao: PokemonDao
 ) : LocalPokemonDataSource {
 
-  override suspend fun fetchPokemon(pokemon: Pokemon) {
+  override suspend fun fetchPokemonList(page: Int): Result<List<Pokemon>, DataError.Local> {
+    return try {
+      val pokemonList = pokemonDao.getPokemonList(page)
+      Result.Success(pokemonList.asDomain())
+    } catch (e: Exception) {
+      Result.Error(DataError.Local.UNKNOWN)
+    }
+  }
 
+  override suspend fun insertPokemon(pokemonList: List<Pokemon>) {
+    pokemonDao.insertPokemon(pokemonList.asEntity())
+  }
+
+  override suspend fun getAllPokemonList(page: Int): Result<List<Pokemon>, DataError.Local> {
+    return try {
+      val pokemonList = pokemonDao.getAllPokemonList(page)
+      Result.Success(pokemonList.asDomain())
+    } catch (e: Exception) {
+      Result.Error(DataError.Local.UNKNOWN)
+    }
   }
 }

--- a/core/database/src/main/java/com/example/core/database/RoomLocalPokemonDataSource.kt
+++ b/core/database/src/main/java/com/example/core/database/RoomLocalPokemonDataSource.kt
@@ -8,7 +8,7 @@ class RoomLocalPokemonDataSource(
   private val pokemonDao: PokemonDao
 ) : LocalPokemonDataSource {
 
-  override suspend fun insertPokemon(pokemon: Pokemon) {
-    TODO("Not yet implemented")
+  override suspend fun fetchPokemon(pokemon: Pokemon) {
+
   }
 }

--- a/core/database/src/main/java/com/example/core/database/RoomLocalPokemonDataSource.kt
+++ b/core/database/src/main/java/com/example/core/database/RoomLocalPokemonDataSource.kt
@@ -8,7 +8,7 @@ class RoomLocalPokemonDataSource(
   private val pokemonDao: PokemonDao
 ) : LocalPokemonDataSource {
 
-  override suspend fun upsertPokemon(pokemon: Pokemon) {
+  override suspend fun insertPokemon(pokemon: Pokemon) {
     TODO("Not yet implemented")
   }
 }

--- a/core/database/src/main/java/com/example/core/database/dao/PokemonDao.kt
+++ b/core/database/src/main/java/com/example/core/database/dao/PokemonDao.kt
@@ -3,6 +3,7 @@ package com.example.core.database.dao
 import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
+import androidx.room.Query
 import com.example.core.database.entity.PokemonEntity
 
 @Dao
@@ -10,4 +11,10 @@ interface PokemonDao {
 
   @Insert(onConflict = OnConflictStrategy.REPLACE)
   suspend fun insertPokemon(pokemonList: List<PokemonEntity>)
+
+  @Query("SELECT * FROM PokemonEntity WHERE page = :page_")
+  suspend fun getPokemonList(page_: Int): List<PokemonEntity>
+
+  @Query("SELECT * FROM PokemonEntity WHERE page <= :page_")
+  suspend fun getAllPokemonList(page_: Int): List<PokemonEntity>
 }

--- a/core/database/src/main/java/com/example/core/database/dao/PokemonDao.kt
+++ b/core/database/src/main/java/com/example/core/database/dao/PokemonDao.kt
@@ -1,12 +1,13 @@
 package com.example.core.database.dao
 
 import androidx.room.Dao
-import androidx.room.Upsert
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
 import com.example.core.database.entity.PokemonEntity
 
 @Dao
 interface PokemonDao {
 
-  @Upsert
-  suspend fun upsertPokemon(pokemon: PokemonEntity)
+  @Insert(onConflict = OnConflictStrategy.REPLACE)
+  suspend fun insertPokemon(pokemonList: List<PokemonEntity>)
 }

--- a/core/database/src/main/java/com/example/core/database/di/DatabaseModule.kt
+++ b/core/database/src/main/java/com/example/core/database/di/DatabaseModule.kt
@@ -1,8 +1,8 @@
 package com.example.core.database.di
 
 import androidx.room.Room
-import com.example.core.database.RoomLocalPokemonDataSource
 import com.example.core.database.PokemonDatabase
+import com.example.core.database.RoomLocalPokemonDataSource
 import com.example.core.domain.content.LocalPokemonDataSource
 import org.koin.android.ext.koin.androidApplication
 import org.koin.core.module.dsl.singleOf
@@ -14,7 +14,7 @@ val databaseModule = module {
     Room.databaseBuilder(
       androidApplication(),
       PokemonDatabase::class.java,
-      "sample.db"
+      "pokemon.db"
     ).build()
   }
   single { get<PokemonDatabase>().pokemonDao() }

--- a/core/database/src/main/java/com/example/core/database/entity/PokemonEntity.kt
+++ b/core/database/src/main/java/com/example/core/database/entity/PokemonEntity.kt
@@ -5,7 +5,7 @@ import androidx.room.PrimaryKey
 
 @Entity
 data class PokemonEntity(
-  @PrimaryKey(autoGenerate = true)
-  val id: Int,
-  val name: String
+  @PrimaryKey val name: String,
+  var page: Int = 0,
+  val url: String,
 )

--- a/core/database/src/main/java/com/example/core/database/entity/mapper/EntityMapper.kt
+++ b/core/database/src/main/java/com/example/core/database/entity/mapper/EntityMapper.kt
@@ -1,0 +1,8 @@
+package com.example.core.database.entity.mapper
+
+interface EntityMapper<Domain, Entity> {
+
+  fun asEntity(domain: Domain): Entity
+
+  fun asDomain(entity: Entity): Domain
+}

--- a/core/database/src/main/java/com/example/core/database/entity/mapper/PokemonEntityMapper.kt
+++ b/core/database/src/main/java/com/example/core/database/entity/mapper/PokemonEntityMapper.kt
@@ -1,0 +1,35 @@
+package com.example.core.database.entity.mapper
+
+import com.example.core.database.entity.PokemonEntity
+import com.example.core.domain.content.Pokemon
+
+object PokemonEntityMapper : EntityMapper<List<Pokemon>, List<PokemonEntity>> {
+
+  override fun asEntity(domain: List<Pokemon>): List<PokemonEntity> {
+    return domain.map { pokemon ->
+      PokemonEntity(
+        page = pokemon.page,
+        name = pokemon.name,
+        url = pokemon.url
+      )
+    }
+  }
+
+  override fun asDomain(entity: List<PokemonEntity>): List<Pokemon> {
+    return entity.map { pokemonEntity ->
+      Pokemon(
+        page = pokemonEntity.page,
+        nameField = pokemonEntity.name,
+        url = pokemonEntity.url
+      )
+    }
+  }
+}
+
+fun List<Pokemon>.asEntity(): List<PokemonEntity> {
+  return PokemonEntityMapper.asEntity(this)
+}
+
+fun List<PokemonEntity>?.asDomain(): List<Pokemon> {
+  return PokemonEntityMapper.asDomain(this.orEmpty())
+}

--- a/core/domain/src/main/java/com/example/core/domain/content/LocalPokemonDataSource.kt
+++ b/core/domain/src/main/java/com/example/core/domain/content/LocalPokemonDataSource.kt
@@ -1,5 +1,5 @@
 package com.example.core.domain.content
 
 interface LocalPokemonDataSource {
-  suspend fun insertPokemon(pokemon: Pokemon)
+  suspend fun fetchPokemon(pokemon: Pokemon)
 }

--- a/core/domain/src/main/java/com/example/core/domain/content/LocalPokemonDataSource.kt
+++ b/core/domain/src/main/java/com/example/core/domain/content/LocalPokemonDataSource.kt
@@ -1,5 +1,10 @@
 package com.example.core.domain.content
 
+import com.example.core.domain.util.DataError
+import com.example.core.domain.util.Result
+
 interface LocalPokemonDataSource {
-  suspend fun fetchPokemon(pokemon: Pokemon)
+  suspend fun insertPokemon(pokemonList: List<Pokemon>)
+  suspend fun fetchPokemonList(page: Int): Result<List<Pokemon>, DataError.Local>
+  suspend fun getAllPokemonList(page: Int): Result<List<Pokemon>, DataError.Local>
 }

--- a/core/domain/src/main/java/com/example/core/domain/content/LocalPokemonDataSource.kt
+++ b/core/domain/src/main/java/com/example/core/domain/content/LocalPokemonDataSource.kt
@@ -1,5 +1,5 @@
 package com.example.core.domain.content
 
 interface LocalPokemonDataSource {
-  suspend fun upsertPokemon(pokemon: Pokemon)
+  suspend fun insertPokemon(pokemon: Pokemon)
 }

--- a/core/domain/src/main/java/com/example/core/domain/content/PokeRepository.kt
+++ b/core/domain/src/main/java/com/example/core/domain/content/PokeRepository.kt
@@ -1,5 +1,7 @@
 package com.example.core.domain.content
 
+import kotlinx.coroutines.flow.Flow
+
 interface PokeRepository {
-  suspend fun fetchPokemons(page: Int): List<Pokemon>
+  fun fetchPokemons(page: Int): Flow<List<Pokemon>>
 }

--- a/core/domain/src/main/java/com/example/core/domain/util/DataError.kt
+++ b/core/domain/src/main/java/com/example/core/domain/util/DataError.kt
@@ -15,5 +15,6 @@ sealed interface DataError : Error {
 
   enum class Local : DataError {
     DISK_FULL,
+    UNKNOWN
   }
 }

--- a/core/presentation/ui/src/main/java/com/example/core/presentation/ui/DataErrorToText.kt
+++ b/core/presentation/ui/src/main/java/com/example/core/presentation/ui/DataErrorToText.kt
@@ -8,6 +8,10 @@ fun DataError.asUiText(): UiText {
       R.string.error_disk_full
     )
 
+    DataError.Local.UNKNOWN -> UiText.StringResource(
+      R.string.error_unknown
+    )
+
     DataError.Network.REQUEST_TIMEOUT -> UiText.StringResource(
       R.string.error_request_timeout
     )


### PR DESCRIPTION
This pull request introduces significant changes to refactor the `HomeScreen` feature and improve the handling of Pokémon data by integrating offline-first data fetching and streamlining the data flow. The key changes include replacing the `HomeState` class, introducing a `toPokemonUi` mapper, modifying the repository to support offline-first behavior, and updating database entities and mappers.

### Refactoring `HomeScreen` and State Management:
* Removed the `HomeState` class and replaced `state.pokemonList` with a `pokemonList` `StateFlow` directly fetched from the `HomeViewModel`. (`[[1]](diffhunk://#diff-5b00bec228eca4910f773f02a8e70d2e1325260d3bd43e07d417189ce786739fL1-L7)`, `[[2]](diffhunk://#diff-571a83622fdbba5599ffea8dfea1a1dfb44411cbc9b28e5a86a124c076a78fe2L19-R41)`, `[[3]](diffhunk://#diff-571a83622fdbba5599ffea8dfea1a1dfb44411cbc9b28e5a86a124c076a78fe2L54-R58)`)
* Added a `toPokemonUi` mapper to convert domain-level Pokémon models into UI models. (`[content/presentation/src/main/java/com/example/content/presentation/home/mapper/pokemonUiMapper.ktR1-R12](diffhunk://#diff-31ca45d812a2f0dc5fe263a7cb70e77a76427619f938d719880fefa5a135a661R1-R12)`)
* Updated `HomeScreen` and its preview to use the new `pokemonList` and `toPokemonUi` mapper. (`[[1]](diffhunk://#diff-571a83622fdbba5599ffea8dfea1a1dfb44411cbc9b28e5a86a124c076a78fe2L67-R67)`, `[[2]](diffhunk://#diff-571a83622fdbba5599ffea8dfea1a1dfb44411cbc9b28e5a86a124c076a78fe2L80-L105)`)

### Offline-First Data Fetching:
* Modified the `PokeRepository` to return a `Flow` of Pokémon lists, enabling reactive updates. (`[[1]](diffhunk://#diff-0e0d8626e837dc624f7a764107c8979f07c873afbe1fbbfb83275c0b219450ccR3-R45)`, `[[2]](diffhunk://#diff-f0f592b7f0bf034ae8a12af9c7904a12e8a90baddbf4328f7b2ac31e6a13ac37R3-R6)`)
* Implemented offline-first logic in `OfflineFirstPokeRepository` to fetch data from the local database first and fallback to remote data if necessary. (`[core/data/src/main/java/com/example/core/data/content/OfflineFirstPokeRepository.ktR3-R45](diffhunk://#diff-0e0d8626e837dc624f7a764107c8979f07c873afbe1fbbfb83275c0b219450ccR3-R45)`)
* Updated the `RoomLocalPokemonDataSource` to include methods for fetching and inserting Pokémon data, with error handling. (`[core/database/src/main/java/com/example/core/database/RoomLocalPokemonDataSource.ktR4-R34](diffhunk://#diff-552fe24ce691148bd2d8e101dc883480539df8f12b5eb59c99f6369ea08056ecR4-R34)`)

### Database Enhancements:
* Updated the `PokemonEntity` to include `page` and `url` fields, aligning with the domain model. (`[core/database/src/main/java/com/example/core/database/entity/PokemonEntity.ktL8-R10](diffhunk://#diff-4c2f5eeb580f95178a9ec7ad82948b06ca5850d95001f074932ef79e1f749ff0L8-R10)`)
* Added mappers (`PokemonEntityMapper`) to convert between database entities and domain models. (`[core/database/src/main/java/com/example/core/database/entity/mapper/PokemonEntityMapper.ktR1-R35](diffhunk://#diff-be4f002f6b34f97ba720e98a00dd0fa12b4f2a0fd5f8960a5b00792724692b51R1-R35)`)
* Updated the `PokemonDao` with new queries for fetching Pokémon data by page and inserting Pokémon entities. (`[core/database/src/main/java/com/example/core/database/dao/PokemonDao.ktL4-R19](diffhunk://#diff-afd634714da8a342920bba74ae892baa87047319af032d2f6b83d19b9cd9d81fL4-R19)`)

### Miscellaneous:
* Added a new `UNKNOWN` error type to `DataError.Local` and updated the error-to-UI mapping. (`[[1]](diffhunk://#diff-5305bbb14bfb77614b79584d69fcb3f9db4fcd679d6db876f1a5fc8d150b76f7R18)`, `[[2]](diffhunk://#diff-6b0ae170bd88fdbf65f1829767bd295cf8a30108c8f6c4efb23c23c522ccdd99R11-R14)`)
* Renamed the database file to `pokemon.db` for better clarity. (`[core/database/src/main/java/com/example/core/database/di/DatabaseModule.ktL17-R17](diffhunk://#diff-05a85525ca146490d930c4f8393e3dcfa2ea63ec47a6a2415e9c4cb6599e2482L17-R17)`)